### PR TITLE
Refactor AuthorizeForm, CheckoutProcess, AuthForms, and routes for st…

### DIFF
--- a/app/components/molecules/AuthorizeForm.tsx
+++ b/app/components/molecules/AuthorizeForm.tsx
@@ -196,7 +196,7 @@ const AuthorizeForm: React.FC<AuthorizeFormProps> = ({
 								<a
 									href={fallbackUrl}
 									rel="noopener noreferrer"
-									className='text-red-500'
+									className="text-red-500"
 								>
 									{' '}
 									click here{' '}
@@ -210,7 +210,7 @@ const AuthorizeForm: React.FC<AuthorizeFormProps> = ({
 								<a
 									href={fallbackUrl}
 									rel="noopener noreferrer"
-									className='text-red-500 no-underline hover:underline'
+									className="text-red-500 no-underline hover:underline"
 								>
 									{' '}
 									click here{' '}

--- a/app/components/molecules/AuthorizeForm.tsx
+++ b/app/components/molecules/AuthorizeForm.tsx
@@ -159,26 +159,9 @@ const AuthorizeForm: React.FC<AuthorizeFormProps> = ({
 
 	return (
 		<div>
-			{showFallback ? (
-				<div id="fallback">
-					<p>
-						Click{' '}
-						<a
-							href={fallbackUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="text-red-700 transition hover:text-red-500 hover:underline"
-						>
-							here
-						</a>{' '}
-						if you&apos;re having trouble linking your Steam account.
-					</p>
-				</div>
-			) : null}
-
 			{!steamPopupOpened && !visible ? (
 				<div className="cta-container">
-					<div className="cta-text">Ready to link your Steam account?</div>
+					<div className="cta-text">Link your Steam account to continue?</div>
 					<button
 						className="steam-button button transition hover:border-none"
 						onClick={initiateSteamLinking}
@@ -206,18 +189,35 @@ const AuthorizeForm: React.FC<AuthorizeFormProps> = ({
 							transform: `translateY(${showAlternative ? '0px' : '20px'})`,
 						}}
 					>
-						Still having trouble? It&apos;s possible your browser blocked the
-						popup. No worries, you can
-						<a
-							href={fallbackUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							style={{ color: 'red', textDecoration: 'underline' }}
-						>
-							{' '}
-							click here{' '}
-						</a>
-						to sign in manually.
+						{showFallback ? (
+							<>
+								We believe your browser may have blocked the popup. No worries,
+								you can
+								<a
+									href={fallbackUrl}
+									rel="noopener noreferrer"
+									className='text-red-500'
+								>
+									{' '}
+									click here{' '}
+								</a>
+								to sign in manually.
+							</>
+						) : (
+							<>
+								Still having trouble? It&apos;s possible your browser blocked
+								the popup. No worries, you can
+								<a
+									href={fallbackUrl}
+									rel="noopener noreferrer"
+									className='text-red-500 no-underline hover:underline'
+								>
+									{' '}
+									click here{' '}
+								</a>
+								to sign in manually.
+							</>
+						)}
 					</p>
 				</div>
 			)}

--- a/app/components/molecules/CheckoutProcess/CheckoutProcess.tsx
+++ b/app/components/molecules/CheckoutProcess/CheckoutProcess.tsx
@@ -61,6 +61,26 @@ const CheckoutProcess: React.FC<CheckoutProcessProps> = ({
 		setBasketExists(!!basketId)
 	}, [basketId])
 
+	const callback = () => {
+		revalidator.revalidate()
+	}
+
+		useEffect(() => {
+			const handleSteamAuthSuccess = (event: MessageEvent) => {
+				if (event.data.type === 'steam-auth-success') {
+					console.log('User has successfully integrated their steam.')
+					callback()
+				}
+			}
+	  
+		  window.addEventListener('message', handleSteamAuthSuccess)
+	  
+		  return () => {
+			window.removeEventListener('message', handleSteamAuthSuccess)
+		}
+		}, []);
+
+
 	/**
 	 * Initializes the Tebex checkout process.
 	 * @param {string} checkoutId - The ID for the Tebex checkout.

--- a/app/components/molecules/CheckoutProcess/CheckoutProcess.tsx
+++ b/app/components/molecules/CheckoutProcess/CheckoutProcess.tsx
@@ -65,21 +65,20 @@ const CheckoutProcess: React.FC<CheckoutProcessProps> = ({
 		revalidator.revalidate()
 	}
 
-		useEffect(() => {
-			const handleSteamAuthSuccess = (event: MessageEvent) => {
-				if (event.data.type === 'steam-auth-success') {
-					console.log('User has successfully integrated their steam.')
-					callback()
-				}
+	useEffect(() => {
+		const handleSteamAuthSuccess = (event: MessageEvent) => {
+			if (event.data.type === 'steam-auth-success') {
+				console.log('User has successfully integrated their steam.')
+				callback()
 			}
-	  
-		  window.addEventListener('message', handleSteamAuthSuccess)
-	  
-		  return () => {
+		}
+
+		window.addEventListener('message', handleSteamAuthSuccess)
+
+		return () => {
 			window.removeEventListener('message', handleSteamAuthSuccess)
 		}
-		}, []);
-
+	}, [])
 
 	/**
 	 * Initializes the Tebex checkout process.

--- a/app/components/organism/AuthForms/AuthForms.tsx
+++ b/app/components/organism/AuthForms/AuthForms.tsx
@@ -1,6 +1,6 @@
 // components/organism/AuthForms/AuthForms.tsx
 
-import { useFetchers, useLoaderData } from '@remix-run/react'
+import { useFetchers, useLoaderData, useRevalidator } from '@remix-run/react'
 import type React from 'react'
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import Button from '~/components/atoms/Button/Button'
@@ -30,9 +30,7 @@ enum PageTitle {
 const AuthForms: React.FC = () => {
 	const { isAuthenticated, isSteamLinked, username, flashSuccess } =
 		useLoaderData<LoaderData>()
-
-	const shouldOpenModal =
-		flashSuccess && flashSuccess.type === 'steam_authorization_success'
+	const [shouldOpenModal, setShouldOpenModal] = useState(true)
 
 	const [isLoginForm, setIsLoginForm] = useState(true)
 	const { submit } = useFetcherWithPromiseAutoReset({
@@ -80,6 +78,17 @@ const AuthForms: React.FC = () => {
 			console.error('An error occurred:', error)
 		}
 	}, [])
+
+useEffect(() => {
+  if (flashSuccess && flashSuccess.type === 'steam_authorization_success') {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event('steam-auth-success'));
+    }
+    setShouldOpenModal(true);
+  }
+}, [flashSuccess]); // Ensure `flashSuccess` isn't changing too frequently
+
+
 
 	const [isInitial, setIsInitial] = useState(true)
 

--- a/app/components/organism/AuthForms/AuthForms.tsx
+++ b/app/components/organism/AuthForms/AuthForms.tsx
@@ -1,6 +1,6 @@
 // components/organism/AuthForms/AuthForms.tsx
 
-import { useFetchers, useLoaderData, useRevalidator } from '@remix-run/react'
+import { useFetchers, useLoaderData } from '@remix-run/react'
 import type React from 'react'
 import { useEffect, useState, useCallback, useMemo } from 'react'
 import Button from '~/components/atoms/Button/Button'
@@ -79,16 +79,14 @@ const AuthForms: React.FC = () => {
 		}
 	}, [])
 
-useEffect(() => {
-  if (flashSuccess && flashSuccess.type === 'steam_authorization_success') {
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new Event('steam-auth-success'));
-    }
-    setShouldOpenModal(true);
-  }
-}, [flashSuccess]); // Ensure `flashSuccess` isn't changing too frequently
-
-
+	useEffect(() => {
+		if (flashSuccess && flashSuccess.type === 'steam_authorization_success') {
+			if (typeof window !== 'undefined') {
+				window.dispatchEvent(new Event('steam-auth-success'))
+			}
+			setShouldOpenModal(true)
+		}
+	}, [flashSuccess]) // Ensure `flashSuccess` isn't changing too frequently
 
 	const [isInitial, setIsInitial] = useState(true)
 

--- a/app/routes/authorize.steam.tsx
+++ b/app/routes/authorize.steam.tsx
@@ -12,8 +12,9 @@ import { generateSteamLoginURL } from '~/utils/steamAuth'
 export const loader: LoaderFunction = ({ request }) => {
 	// The URL to which Steam should redirect the user after login
 	const returnURL = new URL('/authorize/steam/callback', request.url).toString()
-	const steamLoginURL = generateSteamLoginURL(returnURL)
+	const steamLoginURL = generateSteamLoginURL(returnURL, 'main')
+	const steamLoginURLFallBack = generateSteamLoginURL(returnURL, 'fallback')
 
 	// Redirect the user to Steam for authentication
-	return json({ url: steamLoginURL })
+	return json({ url: steamLoginURL, fallback: steamLoginURLFallBack })
 }

--- a/app/routes/store.create.tsx
+++ b/app/routes/store.create.tsx
@@ -6,9 +6,9 @@ import { createTebexBasket } from '~/utils/tebex.server'
 
 const ERROR_MESSAGES = {
 	authentication: 'User must be authenticated',
-	username: 'User must have a username',
-	steamId: 'User must have a Steam ID',
-	basket: 'User already have a package added to a basket',
+	username: 'User must has a username',
+	steamId: 'User must has a Steam ID',
+	basket: 'User already has a package added to a basket',
 }
 
 export const action: ActionFunction = async ({ request }) => {


### PR DESCRIPTION
### Hotfixes

#### `AuthorizeForm.tsx`
- Modified the `showFallback` conditional block to display a different message and link depending on the `showFallback` state.
- Updated the call-to-action text from "Ready to link your Steam account?" to "Link your Steam account to continue?".
- Refactored the "Still having trouble?" block to use a conditional statement with `showFallback`, now displaying two different messages and links.

#### `CheckoutProcess.tsx`
- Added a new callback function to revalidate the checkout process.
- Added a new `useEffect` hook to listen for a `steam-auth-success` message event and call the callback function when received.

#### `AuthForms.tsx`
- Imported the `useRevalidator` hook from `@remix-run/react`.
- Changed the `shouldOpenModal` state from a derived value based on `flashSuccess` to a state variable initialized with `true`.
- Added a new `useEffect` hook to dispatch a `steam-auth-success` event when `flashSuccess` is present and set `shouldOpenModal` to `true`.

#### `authorize.steam.tsx`
- Called the `generateSteamLoginURL` function with an additional `main` parameter.
- Generated a new `steamLoginURLFallBack` variable with the `fallback` parameter.
- The JSON response now includes both `url` and `fallback` properties.

#### `store.create.tsx`
- Minor changes to error message wording, replacing "must be" with "must has" in some cases.
